### PR TITLE
Removed void from phpdoc return type

### DIFF
--- a/src/Contracts/Bus/Dispatcher.php
+++ b/src/Contracts/Bus/Dispatcher.php
@@ -9,17 +9,13 @@ interface Dispatcher
      * Dispatches a Command to the bus.
      *
      * @param Command $command
-     * @return void
      */
-
     public function dispatch(Command $command);
 
     /**
      * Dispatches a Collection of Commands to the bus.
      *
      * @param Collection $commands
-     * @return void
      */
-
     public function dispatch_collection(Collection $commands);
 }


### PR DESCRIPTION
This is more about syntax highlighting and cases where those methods could potentially return values