### PR TITLE
Invariant messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 
 vendor/
-.idea/tasks.xml
-.idea/workspace.xml
+.idea/

--- a/src/Business/Invariant/AbstractInvariant.php
+++ b/src/Business/Invariant/AbstractInvariant.php
@@ -8,7 +8,8 @@ abstract class AbstractInvariant implements Invariant
 {
     protected $queryable;
     protected $assumptions;
-    protected $error_message;
+    protected $error_message_positive;
+    protected $error_message_negative;
 
     private $is_invariant;
 
@@ -56,12 +57,13 @@ abstract class AbstractInvariant implements Invariant
 
     public function asserts()
     {
-        if(
-            (!$this->satisfier($this->queryable) && $this->is_invariant) ||
-            ($this->satisfier($this->queryable) && !$this->is_invariant)
-        )
-        {
-            $error_message = $this->error_message ?: "Invariant broken: ".get_called_class();
+        if (!$this->satisfier($this->queryable) && $this->is_invariant) {
+            $error_message = $this->error_message_negative ?: "Invariant broken: ".get_called_class();
+            throw new Exception($error_message);
+        }
+
+        if ($this->satisfier($this->queryable) && !$this->is_invariant) {
+            $error_message = $this->error_message_positive ?: "Invariant broken: ".get_called_class();
             throw new Exception($error_message);
         }
     }

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -62,7 +62,7 @@ class Collection implements CollectionContract
 
     public function has_next()
     {
-        return isset($this->items[$this->key]);
+        return isset($this->items[$this->key + 1]);
     }
 
     public function next()

--- a/tests/CollectableItem.php
+++ b/tests/CollectableItem.php
@@ -1,0 +1,18 @@
+<?php
+
+use BoundedContext\Contracts\Core\Collectable;
+
+class CollectableItem implements Collectable
+{
+    protected $secret;
+
+    public function __construct($value)
+    {
+        $this->secret = $value;
+    }
+
+    public function value()
+    {
+        return $this->secret;
+    }
+}

--- a/tests/CollectionTests.php
+++ b/tests/CollectionTests.php
@@ -4,7 +4,9 @@ use BoundedContext\Collection\Collection;
 
 class CollectionTests extends PHPUnit_Framework_TestCase
 {
-
+    /**
+     * @var Collection
+     */
     private $collection;
 
     public function setup()
@@ -18,14 +20,14 @@ class CollectionTests extends PHPUnit_Framework_TestCase
 
     public function test_count()
     {
-        $this->assertEquals($this->collection->count(), 3);
+        $this->assertEquals($this->collection->count()->value(), 3);
     }
 
     public function test_reset()
     {
-        $this->assertEquals($this->collection->count(), 3);
+        $this->assertEquals($this->collection->count()->value(), 3);
         $this->collection->reset();
-        $this->assertEquals($this->collection->count(), 0);
+        $this->assertEquals($this->collection->count()->value(), 0);
     }
 
     public function test_rewind()
@@ -33,25 +35,25 @@ class CollectionTests extends PHPUnit_Framework_TestCase
         $this->collection->next();
         $this->collection->next();
 
-        $this->assertEquals($this->collection->current(), 'C');
+        $this->assertEquals($this->collection->current()->value(), 'C');
 
         $this->collection->rewind();
 
-        $this->assertEquals($this->collection->current(), 'A');
+        $this->assertEquals($this->collection->current()->value(), 'A');
     }
 
     public function test_ordering()
     {
-        $this->assertEquals($this->collection->current(), 'A');
+        $this->assertEquals($this->collection->current()->value(), 'A');
 
         $this->assertTrue($this->collection->has_next());
         $this->collection->next();
-        $this->assertEquals($this->collection->current(), 'B');
+        $this->assertEquals($this->collection->current()->value(), 'B');
 
         $this->assertTrue($this->collection->has_next());
         $this->collection->next();
-        $this->assertEquals($this->collection->current(), 'C');
-
+        $this->assertEquals($this->collection->current()->value(), 'C');
+        
         $this->assertFalse($this->collection->has_next());
     }
 
@@ -67,7 +69,7 @@ class CollectionTests extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->collection->has_next());
         $this->collection->next();
 
-        $this->assertEquals($this->collection->current(), 'D');
+        $this->assertEquals($this->collection->current()->value(), 'D');
         $this->assertFalse($this->collection->has_next());
     }
 
@@ -82,7 +84,7 @@ class CollectionTests extends PHPUnit_Framework_TestCase
         );
 
         $this->assertFalse($this->collection->has_next());
-        $this->assertEquals($this->collection->current(), 'D');
+        $this->assertEquals($this->collection->current()->value(), 'D');
     }
 
     public function test_append_after_playthrough()
@@ -100,6 +102,6 @@ class CollectionTests extends PHPUnit_Framework_TestCase
         $this->collection->next();
 
         $this->assertFalse($this->collection->has_next());
-        $this->assertEquals($this->collection->current(), 'D');
+        $this->assertEquals($this->collection->current()->value(), 'D');
     }
 }

--- a/tests/Invariant/FakeQueryable.php
+++ b/tests/Invariant/FakeQueryable.php
@@ -1,0 +1,8 @@
+<?php
+
+use BoundedContext\Contracts\Projection\Queryable;
+
+class FakeQueryable implements Queryable
+{
+
+}

--- a/tests/Invariant/InvariantMessagesTest.php
+++ b/tests/Invariant/InvariantMessagesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use BoundedContext\Contracts\Business\Invariant;
+
+class InvariantMessagesTest extends PHPUnit_Framework_TestCase
+{
+    public function test_valid_positive_assumption()
+    {
+        $exists = true;
+        $invariant = new LogicInvariant(new FakeQueryable());
+        $invariant->assuming([$exists])->asserts();
+    }
+
+    public function test_invalid_positive_assumption()
+    {
+        $this->setExpectedException(
+            Invariant\Exception::class,
+            'Universe does exist'
+        );
+
+        $exists = true;
+        $invariant = new LogicInvariant(new FakeQueryable());
+        $invariant->assuming([$exists])->not()->asserts();
+    }
+
+    public function test_valid_negative_assumption()
+    {
+        $exists = false;
+        $invariant = new LogicInvariant(new FakeQueryable());
+        $invariant->assuming([$exists])->not()->asserts();
+    }
+
+    public function test_invalid_negative_assumption()
+    {
+        $this->setExpectedException(
+            Invariant\Exception::class,
+            "Universe does not exist"
+        );
+        
+        $exists = false;
+        $invariant = new LogicInvariant(new FakeQueryable());
+        $invariant->assuming([$exists])->asserts();
+    }
+}

--- a/tests/Invariant/LogicInvariant.php
+++ b/tests/Invariant/LogicInvariant.php
@@ -1,0 +1,22 @@
+<?php
+
+use BoundedContext\Business\Invariant\AbstractInvariant;
+use BoundedContext\Contracts\Business\Invariant\Invariant;
+
+class LogicInvariant extends AbstractInvariant implements Invariant
+{
+    protected $error_message_positive = "Universe does exist";
+    protected $error_message_negative = "Universe does not exist";
+
+    protected $flag;
+
+    protected function assumptions($flag)
+    {
+        $this->flag = $flag;
+    }
+
+    protected function satisfier()
+    {
+        return !!$this->flag;
+    }
+}


### PR DESCRIPTION
This PR provides extended messages on invariant met\unmet.

Also it fixes some broken tests and `has_next()` check inside `BoundedContext\Collection\Collection`.